### PR TITLE
correct infinite aperture definition for ACS and WFC3; fix supported apertures for WFC3

### DIFF
--- a/docs/stsynphot/appendixb_specialkey.rst
+++ b/docs/stsynphot/appendixb_specialkey.rst
@@ -88,8 +88,10 @@ Encircled Energy
 For :ref:`stsynphot-appendixb-acs` and :ref:`stsynphot-appendixb-wfc3`,
 the ``aper`` keyword is used to specify a circular aperture, given by its
 radius in arcseconds, to calculate the source counts within.
-If no aperture is given, calculations are done for an infinite aperture, which
-is also 5.5 arcsec or larger for ACS, and 2 arcsec or larger for WFC3.
+If no aperture is given, calculations are done for an infinite aperture, where 
+the EE curves are normalized.  For ACS detectors, infinite aperture is defined 
+at a radius of 5.5 arcsec where the EE value is 1.0. For WFC3 detectors, 
+infinite aperture is defined at a radius of 6.0 arcsec, where the EE is 1.0.
 
 This enables **stsynphot** to be more flexible and accurate, particularly for
 cases where red targets are observed at long wavelengths.
@@ -117,7 +119,7 @@ For ACS, the following apertures are supported:
 * 2.0 arcsec
 * 4.0 arcsec
 
-For WFC3, the following apertures are supported:
+For WFC3/IR, the following apertures are supported:
 
 * every 0.05 arcsec between 0.1 and 0.3 arcsec
 * every 0.1 arcsec between 0.3 and 0.6 arcsec
@@ -125,6 +127,12 @@ For WFC3, the following apertures are supported:
 * 1.0 arcsec
 * 1.5 arcsec
 * 2.0 arcsec
+* 6.0 arcsec
+
+For WFC3/UVIS, the following apertures are supported:
+
+* every 0.04 arcsec between 0.04 and 1.98 arcsec
+* 6.0 arcsec
 
 To use this capability in simulations, include ``aper#value`` in the
 ``obsmode`` string, where ``value`` is the radius in arcseconds.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
This PR corrects the definition of an "infinite aperture" for both ACS and WFC3, and splits the WFC3 apertures supported by stsynphot into two lists: one for UVIS and one for IR. 